### PR TITLE
Remove Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # completionist-toolbox
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/YaManicKill/completionist-toolbox.svg)](https://greenkeeper.io/)
-
 ### Dev
 
 * `npm i`


### PR DESCRIPTION
No longer used, possibly can be replaced by [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com/)